### PR TITLE
Added support for region specific Dialogflow instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ Audio File - Count of Channels
 
 Audio File - Separate Recognition per Channel
 
+### DIALOGFLOW_API_ENDPOINT
+
+By default the Dialogflow connector only works with the US (Global) region of Dialogflow, however it can be configured to connect to a region specific version of Dialogflow.  This requires setting the project ID to include the location AND setting a custom API Endpoint for the specific region dialogflow instance.   In this example configuration, an example of the dialogflow region would be `australia-southeast1`.  List of available regions: https://cloud.google.com/dialogflow/es/docs/how/region
+
+```
+{
+  "botium": {
+    "Capabilities": {
+      "PROJECTNAME": "<whatever>",
+      "CONTAINERMODE": "dialogflow",
+      "DIALOGFLOW_PROJECT_ID": "<google project id>/locations/<dialogflow region>",
+      "DIALOGFLOW_CLIENT_EMAIL": "<service credentials email>",
+      "DIALOGFLOW_PRIVATE_KEY": "<service credentials private key>",
+      "DIALOGFLOW_API_ENDPOINT": "<dialogflow region>-dialogflow.googleapis.com"
+    }
+  }
+}
+```
+
 ## Open Issues and Restrictions
 * Account Linking is not supported (Consider using [Botium Connector for Google Assistant](https://github.com/codeforequity-at/botium-connector-google-assistant) if you want to test it)
 * Not [all](https://cloud.google.com/dialogflow-enterprise/docs/reference/rest/v2/projects.agent.intents#Message) dialogflow response is supported, just

--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ const Capabilities = {
   DIALOGFLOW_ENABLE_KNOWLEDGEBASE: 'DIALOGFLOW_ENABLE_KNOWLEDGEBASE',
   DIALOGFLOW_FALLBACK_INTENTS: 'DIALOGFLOW_FALLBACK_INTENTS',
   DIALOGFLOW_AUDIOINPUT_ENCODING: 'DIALOGFLOW_AUDIOINPUT_ENCODING',
-  DIALOGFLOW_AUDIOINPUT_SAMPLERATEHERTZ: 'DIALOGFLOW_AUDIOINPUT_SAMPLERATEHERTZ'
+  DIALOGFLOW_AUDIOINPUT_SAMPLERATEHERTZ: 'DIALOGFLOW_AUDIOINPUT_SAMPLERATEHERTZ',
+  DIALOGFLOW_API_ENDPOINT: 'DIALOGFLOW_API_ENDPOINT'
 }
 
 const Defaults = {
@@ -78,6 +79,10 @@ class BotiumConnectorDialogflow {
       }
     }
 
+    if (this.caps[Capabilities.DIALOGFLOW_API_ENDPOINT]) {
+      this.sessionOpts.apiEndpoint = this.caps[Capabilities.DIALOGFLOW_API_ENDPOINT];
+    }
+
     return Promise.resolve()
   }
 
@@ -104,6 +109,9 @@ class BotiumConnectorDialogflow {
       debug(`Using Dialogflow Knowledge Bases ${util.inspect(this.kbNames)}, switching to v2beta1 version of Dialogflow API`)
       this.sessionClient = new dialogflow.v2beta1.SessionsClient(this.sessionOpts)
       this.queryParams.knowledgeBaseNames = this.kbNames
+    } else if (this.caps[Capabilities.DIALOGFLOW_API_ENDPOINT] != null) {
+      debug(`Using custom api endpoint (for localized dialogflow), switching to v2beta1 version of Dialogflow API`)
+      this.sessionClient = new dialogflow.v2beta1.SessionsClient(this.sessionOpts)
     } else {
       this.sessionClient = new dialogflow.SessionsClient(this.sessionOpts)
     }


### PR DESCRIPTION
Dialogflow now supports agents deployed to other regions different from default US region.   In order to send the commands to that version of Dialogflow we need to connect to a different api endpoint.   See: https://cloud.google.com/dialogflow/es/docs/how/region